### PR TITLE
Use only allowed symbols in PHP variable names

### DIFF
--- a/plugin/phprefactor.vim
+++ b/plugin/phprefactor.vim
@@ -44,10 +44,7 @@ func! PhpRefactorExtractMethod(startline, endline)
 endfunc
 
 func! PhpRefactorLocalVariableToInstanceVariable()
-    set iskeywordOptionOld = &iskeyword
-    set iskeyword-=$
-    let variable = expand('<cword>')
-    set iskeyword = iskeywordOptionOld
+    let variable = <SID>GetVariableNameUnderCursor()
 
     let lineNo = line('.')
 
@@ -57,7 +54,7 @@ func! PhpRefactorLocalVariableToInstanceVariable()
 endfunc
 
 func! PhpRefactorRenameLocalVariable()
-    let oldName = expand('<cword>')
+    let oldName = <SID>GetVariableNameUnderCursor()
     let lineNo = line('.')
     let newName = input('Enter new variable name: ')
 
@@ -86,4 +83,15 @@ func! PhpRefactorRunCommand(refactoring, args)
     exec command . ' | ' . g:php_refactor_patch_command
     exec ':redraw!'
     echo command . ' | ' . g:php_refactor_patch_command
+endfunc
+
+func! s:GetVariableNameUnderCursor()
+    let iskeywordOptionOld = &iskeyword
+    set iskeyword=a-z,A-Z,48-57,_
+
+    let variableName = expand('<cword>')
+
+    let &iskeyword = iskeywordOptionOld
+
+    return variableName
 endfunc

--- a/plugin/phprefactor.vim
+++ b/plugin/phprefactor.vim
@@ -44,7 +44,11 @@ func! PhpRefactorExtractMethod(startline, endline)
 endfunc
 
 func! PhpRefactorLocalVariableToInstanceVariable()
+    set iskeywordOptionOld = &iskeyword
+    set iskeyword-=$
     let variable = expand('<cword>')
+    set iskeyword = iskeywordOptionOld
+
     let lineNo = line('.')
 
     let args = [lineNo, variable]


### PR DESCRIPTION
When &iskeyword Vim option contains symbol '$' and user tries to rename local variable then commandline argument of "refactor"-script contains this symbol too. This leads to error and unsafe.
